### PR TITLE
Add 'sync' update method for roles and playbooks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,6 +55,8 @@ debops_install_systemwide: True
 #
 # - ``async``: use ``async`` Ansible support, does not create any output;
 #
+# - ``sync``: immediately sync and only continue after everything is in place
+#
 debops_update_method: '{{ ("batch"
                            if (ansible_local|d() and ansible_local.atd|d() and
                                ansible_local.atd.enabled|bool)

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -20,11 +20,18 @@ Another alternative is to disable APT Ansible package and enable installation
 from PyPI alongside ``debops`` package. However, APT method is preferred, since
 it automatically installs all required APT packages.
 
-The ``debops.debops`` role will install the DebOps playbooks and roles from GitHub
-in the background, using either the ``batch`` command from the ``at`` package, or
-if the former is not available, ``async`` Ansible task. Keep in mind that
-downloading all of the repositories might take a while and the code won't be
+By default the ``debops.debops`` role will install the DebOps playbooks and roles
+from GitHub in the background, using either the ``batch`` command from the ``at``
+package, or if the former is not available, ``async`` Ansible task. Keep in mind
+that downloading all of the repositories might take a while and the code won't be
 available for some time after initial Ansible playbook run.
+
+If you cannot accept this behaviour you can set ``debops_update_method`` to
+``sync``. This will make the roles and playbooks immediately available after the
+task is run. However, this will introduce a significant delay in every playbook
+run even when no upstream changes will be found. You should only choose this if
+you plan to run ``debops`` from the same playbook where you also include the
+``debops.debops`` role, e.g. when provisioning a new DebOps environment.
 
 Example inventory
 -----------------

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,12 +4,13 @@
   command: debops-update
   async: '{{ debops_async_timeout | int }}'
   poll: 0
-  when: debops_install_systemwide|bool
+  when: debops_install_systemwide|bool and
+        not debops_update_method == 'sync'
 
 - name: Update DebOps in the background with batch
   shell: |
     type debops-update > /dev/null 2>&1 && (echo 'debops-update' | batch > /dev/null 2>&1) || true
   when: (debops_install_systemwide|bool and
          (ansible_local|d() and ansible_local.atd|d() and
-          ansible_local.atd.enabled|bool))
-
+          ansible_local.atd.enabled|bool) and
+         not debops_update_method == 'sync')

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,8 +17,13 @@
     name: '{{ item }}'
     state: 'present'
   with_items: debops_pip_packages
-  notify: [ 'Update DebOps in the background with {{ debops_update_method }}' ]
+  notify: '[ "Update DebOps in the background with {{ debops_update_method }}" ] if debops_update_method is not "sync" else []'
   when: item|d()
+
+- name: Update roles and playbooks
+  command: debops-update
+  when: debops_install_systemwide|bool and
+        debops_update_method == 'sync'
 
 - name: Configure system-wide DebOps scripts
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
     name: '{{ item }}'
     state: 'present'
   with_items: debops_pip_packages
-  notify: '[ "Update DebOps in the background with {{ debops_update_method }}" ] if debops_update_method is not "sync" else []'
+  notify: [ 'Update DebOps in the background with {{ debops_update_method }}' ]
   when: item|d()
 
 - name: Update roles and playbooks


### PR DESCRIPTION
Allow roles and playbooks to be updated synchronously in case `debops` should be run later in the playbook.