### PR TITLE
Install roles for ansible user if systemwide is false

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,8 +41,9 @@ debops_pip_packages: [ 'debops' ]
 
 # .. envvar:: debops_install_systemwide
 #
-# Download playbooks and roles to a system-wide location in the background, on
-# installation.
+# Download playbooks and roles to a system-wide location, on installation. If
+# set to ``False`` the playbooks and roles will be installed locally for the
+# current Ansible user.
 debops_install_systemwide: True
 
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -8,7 +8,7 @@ data center environment based on Debian GNU/Linux distribution.
 This role installs the DebOps scripts, playbooks and roles on a specified host.
 It can be used to create remote Ansible Controller hosts, which then can be
 used to control other hosts using DebOps. Roles and playbooks will be installed
-in a central, system-wide location, available to all users.
+by default in a central, system-wide location, available to all users.
 
 Installation
 ~~~~~~~~~~~~

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,16 +1,16 @@
 ---
 
 - name: Update DebOps in the background with async
+  become: debops_install_systemwide|bool
   command: debops-update
   async: '{{ debops_async_timeout | int }}'
   poll: 0
-  when: debops_install_systemwide|bool and
-        not debops_update_method == 'sync'
+  when: not debops_update_method == 'sync'
 
 - name: Update DebOps in the background with batch
+  become: debops_install_systemwide|bool
   shell: |
     type debops-update > /dev/null 2>&1 && (echo 'debops-update' | batch > /dev/null 2>&1) || true
-  when: (debops_install_systemwide|bool and
+  when: (not debops_update_method == 'sync' and
          (ansible_local|d() and ansible_local.atd|d() and
-          ansible_local.atd.enabled|bool) and
-         not debops_update_method == 'sync')
+          ansible_local.atd.enabled|bool))

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,6 @@
     mode: '0644'
 
 - name: Update roles and playbooks
+  become: debops_install_systemwide|bool
   command: debops-update
-  when: debops_install_systemwide|bool and
-        debops_update_method == 'sync'
+  when: debops_update_method == 'sync'

--- a/templates/etc/debops.cfg.j2
+++ b/templates/etc/debops.cfg.j2
@@ -2,6 +2,8 @@
 
 # DebOps system-wide configuration
 
+{% if debops_install_systemwide|bool %}
 [paths]
 data-home = {{ debops_data_path }}
 
+{% endif %}


### PR DESCRIPTION
If `debops_install_systemwide` is set to `False` install playbooks and roles for current Ansible user instead of not installing them at all.