### PR TITLE
Fixes for non-default code path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,13 @@ The current role maintainer is drybjed.
 
 .. _debops.debops master: https://github.com/debops/ansible-debops/compare/v0.2.1...master
 
+Fixed
+~~~~~
+
+- Fix sudo behaviour when ``debops__install_systemwide`` is enabled. [ganto]
+
+- Don't trigger role update handler when ``debops__update_method`` is sync. [ganto]
+
 
 `debops.debops v0.2.1`_ - 2016-07-14
 ------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@ Fixed
 
 - Don't trigger role update handler when ``debops__update_method`` is sync. [ganto]
 
+- Only install system-wide ``debops.cfg`` if requested. [ganto]
+
 
 `debops.debops v0.2.1`_ - 2016-07-14
 ------------------------------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,7 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
+  when: debops__install_systemwide|bool
 
 - name: Update roles and playbooks
   become: '{{ debops__install_systemwide|bool }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
     name: '{{ item }}'
     state: 'present'
   with_items: '{{ debops__pip_packages }}'
-  notify: [ 'Update DebOps in the background with {{ debops__update_method }}' ]
+  notify: '{{ [ "Update DebOps in the background with " + debops__update_method ] if not debops__update_method == "sync" else omit }}'
   when: item|d()
 
 - name: Configure system-wide DebOps scripts


### PR DESCRIPTION
My recent testing with [vagrant_debops](https://github.com/ganto/ansible-vagrant_debops) revealed some bugs in the non-default code path of this role when using `debops__install_systemwide: False` and `debops__update_method: sync`. This PR will fix the issues and also add a changelog entry for my last fix from #16.