### PR TITLE
ansible_ssh_user -> ansible_user

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,8 +71,8 @@ debops__ansible_git_build_dir: '{{ (ansible_local.root.src
 # The role will switch to the admin user account to perform the build. The
 # build script needs :command:`sudo` access to install the built ``*.deb`` package,
 # which the admin account should have.
-debops__ansible_git_become_user: '{{ ansible_ssh_user
-                                     if ansible_ssh_user|d()
+debops__ansible_git_become_user: '{{ ansible_user
+                                     if ansible_user|d()
                                      else lookup("env", "USER") }}'
                                                                    # ]]]
                                                                    # ]]]


### PR DESCRIPTION
Since Ansible 2.0.0 ansible_ssh_user is replaced by ansible_user