### PR TITLE
Ansible 1.9.0 -> Ansible 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ be installed in a central, system-wide location, available to all users.
 
 ### Installation
 
-This role requires at least Ansible `v1.9.0`. To install it, run:
+This role requires at least Ansible `v2.0.0`. To install it, run:
 
     ansible-galaxy install debops.debops
 


### PR DESCRIPTION
As ansible_ssh_user is replaced by ansible_user, minimum Ansible 2.0.0 is required