### PR TITLE
Ansible 1.9.0 -> Ansible 2.0.0

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -13,7 +13,7 @@ by default in a central, system-wide location, available to all users.
 Installation
 ~~~~~~~~~~~~
 
-This role requires at least Ansible ``v1.9.0``. To install it, run:
+This role requires at least Ansible ``v2.0.0``. To install it, run:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
As ansible_ssh_user is replaced by ansible_user, minimum Ansible 2.0.0 is required