### PR TITLE
Ansible 1.9.0 -> Ansible 2.0.0

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   description: 'Install DebOps scripts, playbooks and roles using Ansible'
   company: 'DebOps'
   license: 'GPL-3.0'
-  min_ansible_version: '1.9.0'
+  min_ansible_version: '2.0.0'
   platforms:
   - name: Ubuntu
     versions:


### PR DESCRIPTION
As ansible_ssh_user is replaced by ansible_user, minimum Ansible 2.0.0 is required